### PR TITLE
Added rule for gvim

### DIFF
--- a/update-rules.json
+++ b/update-rules.json
@@ -385,6 +385,17 @@
     },
     "version_extractor": "INSTALLER-([0-9]*(?:\\.[0-9]+)*[a-z]?)-RELEASE\\.exe"
   },
+  "gvim": {
+    "url": "http://www.vim.org/download.php",
+    "updater": {
+      "x86":{
+        "rule_type": "css-link",
+	"selector": "[href$='.exe']",
+        "filter": "^.*gvim([^\\\"]*)\\.exe"
+      }
+    },
+    "version_extractor": "gvim([^.]*).exe"
+  },
   "hashcheck": {
     "url": "https://api.github.com/repos/gurnec/HashCheck/releases/latest",
     "updater": {


### PR DESCRIPTION
It works for me(tm), but fwiw debian (debian sid!) ships node 4.6.1, which fails to grok
(at least) default parameters; if all the cursing led me to some silly mistake, let me know
and I'll fix asap.